### PR TITLE
(FIX) Truncate HealthCheck `Output` in template data

### DIFF
--- a/dependency/health_service.go
+++ b/dependency/health_service.go
@@ -156,6 +156,12 @@ func (d *HealthServiceQuery) Fetch(clients *ClientSet, opts *QueryOptions) (inte
 			address = entry.Node.Address
 		}
 
+		// NOTE: Trucnate the `output` for the healthcheck since it can be large if the results are a full
+		// HTML document.
+		for _, chk := range entry.Checks {
+			chk.Output = ""
+		}
+
 		list = append(list, &HealthService{
 			Node:                entry.Node.Node,
 			NodeID:              entry.Node.ID,


### PR DESCRIPTION
Because the Output of a healthcheck can be a full HTML document, we're
truncating the value before storing in Consul so that we don't blow the
byte limit on a KV entry.